### PR TITLE
Add support for custom endpoints in `Claude` and `ChatGPT` classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,20 @@ Below analyzes the `/path/to/target/repo/server.py` file using GPT-4o. Can also 
 python vulnhuntr.py -r /path/to/target/repo/ -a server.py -l gpt 
 ```
 
+### Configuring Custom Endpoints
+
+You can configure custom endpoints for the LLM providers by setting the following environment variables:
+
+- For Claude: `ANTHROPIC_API_ENDPOINT`
+- For GPT: `OPENAI_API_ENDPOINT`
+
+Example:
+
+```bash
+export ANTHROPIC_API_ENDPOINT="https://custom-anthropic-endpoint.com"
+export OPENAI_API_ENDPOINT="https://custom-openai-endpoint.com"
+```
+
 ## Logic Flow
 ![VulnHuntr logic](https://github.com/user-attachments/assets/7757b053-36ff-425e-ab3d-ab0100c81d49)
 - LLM summarizes the README and includes this in the system prompt

--- a/vulnhuntr/LLMs.py
+++ b/vulnhuntr/LLMs.py
@@ -73,7 +73,7 @@ class LLM:
 class Claude(LLM):
     def __init__(self, system_prompt: str = "") -> None:
         super().__init__(system_prompt)
-        self.client = anthropic.Anthropic(max_retries=3)
+        self.client = anthropic.Anthropic(max_retries=3, api_url=os.getenv("ANTHROPIC_API_ENDPOINT", "https://api.anthropic.com"))
 
     def create_messages(self, user_prompt: str) -> List[Dict[str, str]]:
         if "Provide a very concise summary of the README.md content" in user_prompt:
@@ -107,7 +107,7 @@ class Claude(LLM):
 class ChatGPT(LLM):
     def __init__(self, system_prompt: str = "") -> None:
         super().__init__(system_prompt)
-        self.client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))  # Retrieves API key from environment variable
+        self.client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"), api_base=os.getenv("OPENAI_API_ENDPOINT", "https://api.openai.com"))  # Retrieves API key from environment variable
 
     def create_messages(self, user_prompt: str) -> List[Dict[str, str]]:
         messages = [{"role": "system", "content": self.system_prompt}, {"role": "user", "content": user_prompt}]


### PR DESCRIPTION
* **Claude class**
  - Use `ANTHROPIC_API_ENDPOINT` environment variable for custom endpoint

* **ChatGPT class**
  - Use `OPENAI_API_ENDPOINT` environment variable for custom endpoint

* **Documentation**
  - Add instructions for configuring custom endpoints using `ANTHROPIC_API_ENDPOINT` and `OPENAI_API_ENDPOINT` environment variables in `README.md`