### PR TITLE
fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -484,4 +484,5 @@ typing-extensions==4.12.2 ; python_version >= "3.10" and python_version < "4.0" 
 urllib3==2.2.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472 \
     --hash=sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168
-python-dotenv==1.0.0
+python-dotenv==1.0.0 \
+    --hash=sha256:f5971a9226b701070a4bf2c38c89e5a3f0d64de8debda981d1db98583009122a


### PR DESCRIPTION
add package hash for python-dotenv==1.0.0

resolved the issue of the missing hash for the python-dotenv package in the requirements under --require-hashes mode